### PR TITLE
Add application/vnd.apple.mpegurl to the list of mime types

### DIFF
--- a/mimes.js
+++ b/mimes.js
@@ -8,4 +8,5 @@ var MIMES = [
 	"audio/3gpp2", 
 	"application/mp4", 
 	"application/mp21", 
+	"application/vnd.apple.mpegurl",
 ];


### PR DESCRIPTION
Hello!

First, thanks for the great job on developing this page 👍 

Second, I was wondering if it would make sense to add the proposed mime type for HLS streams to the list. 

See https://tools.ietf.org/html/draft-pantos-http-live-streaming-23 & https://www.iana.org/assignments/media-types/application/vnd.apple.mpegurl

Maybe `application/x-mpegURL` could be added too?