### PR TITLE
use a template string

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,12 @@ function addMimeChecks(table,mime,desc) {
 		mediasource_result = e.message; 
 	}
 	tr = document.createElement("tr");
-	tr.innerHTML = "<td id='"+mime+"'>"+desc+"</td><td><a href='#"+mime+"'>"+mime+"</a></td><td class='"+(video_result === ""? "fail" : (video_result === "maybe" ? "maybe": "ok"))+"'>"+(video_result.length > 0 ? video_result : "no")+"</td><td class='"+(mediasource_result === true ? "ok" : "fail")+"'>"+mediasource_result+"</td>";
+	tr.innerHTML = `
+<td id='${mime}'>${desc}</td>
+<td><a href='#${mime}'>${mime}</a></td>
+<td class='${(video_result === ``? `fail` : (video_result === `maybe` ? `maybe`: `ok`))}'>${(video_result.length > 0 ? video_result : `no`)}</td>
+<td class='${(mediasource_result === true ? `ok` : `fail`)}'>${mediasource_result}</td>
+`;
 	table.appendChild(tr);
 }
 


### PR DESCRIPTION
not a functional change, but cleans things up a tad.

i was going to add a `MediaRecorder.isTypeSupported` column to this, but since it only supports the webm container, and your page doesn't have any webm types... it didn't seem like a match

anyway.. this potentially useful change was thanks to that.